### PR TITLE
Watch supervisor on configure

### DIFF
--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -780,4 +780,26 @@ public class HCALFunctionManager extends UserFunctionManager {
 		return "";
 	}
 
+	/**----------------------------------------------------------------------
+	 * go to the error state, setting messages and so forth, with exception
+	 */
+	public void goToError(String errMessage, Exception e) {
+		logger.error(errMessage,e);
+		sendCMSError(errMessage);
+		getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));
+		getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT("oops - technical difficulties ..."+errMessage)));
+		if (theEventHandler.TestMode.equals("off")) { firePriorityEvent(HCALInputs.SETERROR); ErrorState = true; }
+	}
+
+	/**----------------------------------------------------------------------
+	 * go to the error state, setting messages and so forth, without exception
+	 */
+	public void goToError(String errMessage) {
+		logger.error(errMessage);
+		sendCMSError(errMessage);
+		getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));
+		getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT("oops - technical difficulties ..."+errMessage)));
+		if (theEventHandler.TestMode.equals("off")) { firePriorityEvent(HCALInputs.SETERROR); ErrorState = true; }
+	}
+
 }


### PR DESCRIPTION
- Poll supervisor every 5 seconds instead of 20
- Ask also for supervisor stateName, not just partitionState/globalStatus
- Add functions for sending FM to error state, taking in an error message or error message + exception
